### PR TITLE
Use attributes for config file

### DIFF
--- a/templates/default/sysconfig.erb
+++ b/templates/default/sysconfig.erb
@@ -13,7 +13,7 @@ ES_HOME=<%= node['elasticsearch']['home_dir'] %>
 CONF_DIR=<%= node['elasticsearch']['conf_dir'] %>
 
 # Elasticsearch configuration file
-CONF_FILE=$CONF_DIR/elasticsearch.yml
+CONF_FILE=<%= node['elasticsearch']['conf_file'] %>
 
 # Elasticsearch data directory
 DATA_DIR=<%= node['elasticsearch']['data_dir'] %>


### PR DESCRIPTION
Environment variable `$CONF_DIR` causes elasticsearch unable to start.

```
FailedToResolveConfigException[Failed to resolve config path [$CONF_DIR/elasticsearch.yml], tried file path [$CONF_DIR/elasticsearch.yml], path file [/etc/elasticsearch/$CONF_DIR/elasticsearch.yml], and classpath]
```
