### PR TITLE
- set databag config related attributes before generating template file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,30 @@ to elasticsearch nodes run list
 * `default['elasticsearch']['config']['script.disable_dynamic']` (default: `true`): elasticsearch configuration parameter
 
 
+# ElasticSearch Configuration From Data Bag Item
+
+
+* `default['elasticsearch']['databag_configs']` (default: `nil`): elasticsearch configuration parameters from data bag
+  * For example, following configuration will get data bag named 'aws_keys' and data bag item 'elasticsearch'.
+  * The key of 'config_items' will be used as configuration name.
+  * The value of 'config_items' will be used for fetching value from data bag.
+
+```
+'elasticsearch' => {
+    'databag_configs' => [
+      {
+        'name' => 'aws_keys',
+        'item' => 'elasticsearch',
+        'config_items' => {
+          'cloud.aws.access_key' => 'data_bag_key_for_access_key',
+          'cloud.aws.secret_key' => 'data_bag_key_for_secret_key'
+        }
+      }
+    ]
+}
+```
+
+
 # Elasticsearch YUM/APT Repository Attributes
 
 * `default['elasticsearch']['repo_version']` (default: `calculated`): elasticsearch repository version

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,3 +60,5 @@ default['elasticsearch']['sysconfig']['MAX_OPEN_FILES']         = 65_535
 default['elasticsearch']['sysconfig']['MAX_LOCKED_MEMORY']      = 'unlimited'
 default['elasticsearch']['sysconfig']['MAX_MAP_COUNT']          = 262_144
 default['elasticsearch']['sysconfig']['ES_RESTART_ON_UPGRADE']  = true
+
+default['elasticsearch']['databag_configs'] = nil

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -57,7 +57,7 @@ template node['elasticsearch']['conf_file'] do
   owner node['elasticsearch']['user']
   group node['elasticsearch']['group']
   mode 0600
-  sensitive true
+  sensitive true if respond_to?(:sensitive)
   variables(:config => config)
   notifies :restart, 'service[elasticsearch]', :delayed if node['elasticsearch']['notify_restart']
 end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -43,13 +43,22 @@ if node['elasticsearch']['use_chef_search']
   node.default['elasticsearch']['config']['discovery.zen.ping.unicast.hosts'] = search_cluster_nodes(node.chef_environment, node['elasticsearch']['search_role_name'], node['elasticsearch']['search_cluster_name_attr'], node[node['elasticsearch']['search_cluster_name_attr']])
 end
 
+config = node['elasticsearch'][node['elasticsearch']['config_attribute']].to_h
+node['elasticsearch']['databag_configs'].each do |databag|
+  data_bag_item = Chef::EncryptedDataBagItem.load(databag['name'], databag['item'])
+  databag['config_items'].each do |k, v|
+    config[k] = data_bag_item[v]
+  end
+end if node['elasticsearch']['databag_configs']
+
 template node['elasticsearch']['conf_file'] do
   cookbook node['elasticsearch']['cookbook']
   source 'elasticsearch.yml.erb'
-  owner 'root'
-  group 'root'
-  mode 0644
-  variables(:config => node['elasticsearch'][node['elasticsearch']['config_attribute']])
+  owner node['elasticsearch']['user']
+  group node['elasticsearch']['group']
+  mode 0600
+  sensitive true
+  variables(:config => config)
   notifies :restart, 'service[elasticsearch]', :delayed if node['elasticsearch']['notify_restart']
 end
 


### PR DESCRIPTION
Set databag config related attributes before generating template file. Instead of storing in chef node.
### ElasticSearch Configuration From Data Bag Item
- `default['elasticsearch']['databag_configs']` (default: `nil`): elasticsearch configuration parameters from data bag
  - For example, following configuration will get data bag named 'aws_keys' and data bag item 'elasticsearch'.
  - The key of 'config_items' will be used as configuration name.
  - The value of 'config_items' will be used for fetching value from data bag.

```
'elasticsearch' => {
    'databag_configs' => [
      {
        'name' => 'aws_keys',
        'item' => 'elasticsearch',
        'config_items' => {
          'cloud.aws.access_key' => 'data_bag_key_for_access_key',
          'cloud.aws.secret_key' => 'data_bag_key_for_secret_key'
        }
      }
    ]
}
```
