### PR TITLE
ES 5.0 support

### DIFF
--- a/attributes/config_v5.rb
+++ b/attributes/config_v5.rb
@@ -73,7 +73,7 @@ default['elasticsearch']['config_v5']['transport.tcp.compress'] = true
 default['elasticsearch']['config_v5']['http.port'] = 9_200
 #
 # For more information, see the documentation at:
-# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
+# <http://www.elastic.co/guide/en/elasticsearch/reference/5.0/modules-network.html>
 #
 # --------------------------------- Discovery ----------------------------------
 #
@@ -92,7 +92,7 @@ default['elasticsearch']['config_v5']['discovery.zen.fd.ping_timeout'] = '3s'
 #default['elasticsearch']['config_v5']['discovery.zen.ping.multicast.enabled'] = false
 #
 # For more information, see the documentation at:
-# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
+# <http://www.elastic.co/guide/en/elasticsearch/reference/5.0/modules-discovery.html>
 #
 # ---------------------------------- Gateway -----------------------------------
 #
@@ -101,7 +101,7 @@ default['elasticsearch']['config_v5']['discovery.zen.fd.ping_timeout'] = '3s'
 #gateway.recover_after_nodes: 3
 #
 # For more information, see the documentation at:
-# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
+# <http://www.elastic.co/guide/en/elasticsearch/reference/5.0/modules-gateway.html>
 #
 # ---------------------------------- Various -----------------------------------
 #

--- a/attributes/config_v5.rb
+++ b/attributes/config_v5.rb
@@ -1,0 +1,119 @@
+# ======================== Elasticsearch Configuration =========================
+#
+# Please see the documentation for further information on configuration options:
+#
+# ---------------------------------- Cluster -----------------------------------
+#
+# Use a descriptive name for your cluster:
+#
+#cluster.name: my-application
+default['elasticsearch']['config_v5']['cluster.name'] = nil
+#
+# ------------------------------------ Node ------------------------------------
+#
+# Use a descriptive name for the node:
+#
+#node.name: node-1
+default['elasticsearch']['config_v5']['node.name'] = node.name
+default['elasticsearch']['config_v5']['node.master'] = true
+default['elasticsearch']['config_v5']['node.data'] = true
+default['elasticsearch']['config_v5']['node.ingest'] = true
+#
+# Add custom attributes to the node:
+#
+#node.attr.rack: r1
+# Pre 5.0 attributes
+#default['elasticsearch']['config']['node.rack'] = nil
+default['elasticsearch']['config_v5']['node.attr.rack'] = nil
+default['elasticsearch']['config_v5']['node.attr.dc'] = nil
+default['elasticsearch']['config_v5']['node.attr.size'] = nil
+#
+# ----------------------------------- Paths ------------------------------------
+#
+# Path to directory where to store the data (separate multiple locations by comma):
+#
+#path.data: /path/to/data
+default['elasticsearch']['config_v5']['path.data'] = nil
+#
+# Path to log files:
+#
+#path.logs: /path/to/logs
+default['elasticsearch']['config_v5']['path.logs'] = '/var/log/elasticsearch'
+#
+# ----------------------------------- Memory -----------------------------------
+#
+# Lock the memory on startup:
+#
+#bootstrap.memory_lock: true
+# Pre 5.0 attributes
+#default['elasticsearch']['config']['bootstrap.mlockall'] = true
+default['elasticsearch']['config_v5']['bootstrap.memory_lock'] = true
+#
+# Make sure that the heap size is set to about half the memory available
+# on the system and that the owner of the process is allowed to use this
+# limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#
+# ---------------------------------- Network -----------------------------------
+#
+# Set the bind address to a specific IP (IPv4 or IPv6):
+#
+#network.host: 192.168.0.1
+# Pre 5.0 attributes
+#default['elasticsearch']['config']['network.bind_host'] = node['ipaddress']
+#default['elasticsearch']['config']['network.publish_host'] = node['ipaddress']
+default['elasticsearch']['config_v5']['network.host'] = node['ipaddress']
+#
+# Set a custom port for HTTP:
+#
+#http.port: 9200
+default['elasticsearch']['config_v5']['transport.tcp.port'] = 9_300
+default['elasticsearch']['config_v5']['transport.tcp.compress'] = true
+default['elasticsearch']['config_v5']['http.port'] = 9_200
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html>
+#
+# --------------------------------- Discovery ----------------------------------
+#
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
+#
+#discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+default['elasticsearch']['config_v5']['discovery.zen.ping.unicast.hosts'] = []
+#
+# Prevent the "split brain" by configuring the majority of nodes (total number of nodes / 2 + 1):
+#
+#discovery.zen.minimum_master_nodes: 3
+default['elasticsearch']['config_v5']['discovery.zen.minimum_master_nodes'] = 1
+default['elasticsearch']['config_v5']['discovery.zen.fd.ping_timeout'] = '3s'
+# Removed from ES 5.0
+#default['elasticsearch']['config_v5']['discovery.zen.ping.multicast.enabled'] = false
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery.html>
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+#gateway.recover_after_nodes: 3
+#
+# For more information, see the documentation at:
+# <http://www.elastic.co/guide/en/elasticsearch/reference/current/modules-gateway.html>
+#
+# ---------------------------------- Various -----------------------------------
+#
+# Disable starting multiple nodes on a single system:
+#
+#node.max_local_storage_nodes: 1
+default['elasticsearch']['config_v5']['node.max_local_storage_nodes'] = 1
+#
+# Require explicit names when deleting indices:
+#
+#action.destructive_requires_name: true
+# Pre 5.0 attributes
+#default['elasticsearch']['config']['action.auto_create_index'] = true
+default['elasticsearch']['config_v5']['action.destructive_requires_name'] = true
+default['elasticsearch']['config_v5']['action.auto_create_index'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,3 +54,4 @@ default['elasticsearch']['sysconfig']['ES_RESTART_ON_UPGRADE']  = true
 
 default['elasticsearch']['databag_configs'] = nil
 default['elasticsearch']['scripts'] = {}
+default['elasticsearch']['jvm_options_file'] = '/etc/elasticsearch/jvm.options'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -80,6 +80,15 @@ notify_service_start = if (node['elasticsearch']['service_action'].is_a?(Array) 
                          true
                        end
 
+template node['elasticsearch']['jvm_options_file'] do
+  cookbook node['elasticsearch']['cookbook']
+  source 'jvm.options.erb'
+  owner node['elasticsearch']['user']
+  group node['elasticsearch']['group']
+  mode 0600
+  notifies :restart, 'service[elasticsearch]' if node['elasticsearch']['notify_restart']
+end
+
 ruby_block 'delay elasticsearch service start' do
   block do
   end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-raise "require value for node['elasticsearch']['config']['cluster.name']" unless node['elasticsearch'][node['elasticsearch']['config_attribute']]['cluster.name']
+raise "require value for node['elasticsearch']['#{node['elasticsearch']['config_attribute']}']['cluster.name']" unless node['elasticsearch'][node['elasticsearch']['config_attribute']]['cluster.name']
 
 directory node['elasticsearch']['conf_dir'] do
   mode node['elasticsearch']['dir_mode']

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-raise "require value for node['elasticsearch']['config']['cluster.name']" unless node['elasticsearch']['config']['cluster.name']
+raise "require value for node['elasticsearch']['config']['cluster.name']" unless node['elasticsearch'][node['elasticsearch']['config_attribute']]['cluster.name']
 
 directory node['elasticsearch']['conf_dir'] do
   mode node['elasticsearch']['dir_mode']

--- a/spec/unit/recipes/config_spec.rb
+++ b/spec/unit/recipes/config_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'elasticsearch-cluster::config' do
+  shared_examples_for 'elasticsearch' do
+    context 'all_platforms' do
+
+      it 'create template elasticsearch jvm configuration file /etc/elasticsearch/jvm.options' do
+        expect(chef_run).to create_template('/etc/elasticsearch/jvm.options').with(
+          cookbook: 'elasticsearch-cluster',
+          source: 'jvm.options.erb',
+          owner: 'elasticsearch',
+          group: 'elasticsearch',
+          mode: 0600
+        )
+        expect(chef_run.template('/etc/elasticsearch/jvm.options')).to notify('service[elasticsearch]').to(:restart).immediately
+      end
+    end
+  end
+end

--- a/spec/unit/recipes/config_spec.rb
+++ b/spec/unit/recipes/config_spec.rb
@@ -3,6 +3,27 @@ require 'spec_helper'
 describe 'elasticsearch-cluster::config' do
   shared_examples_for 'elasticsearch' do
     context 'all_platforms' do
+      it 'create directory elasticsearch conf_dir' do
+        expect(chef_run).to create_directory('/etc/elasticsearch').with(
+          mode: '0755'
+        )
+      end
+
+      it 'create directory elasticsearch scripts_dir' do
+        expect(chef_run).to create_directory('/etc/elasticsearch/scripts').with(
+          owner: 'elasticsearch',
+          group: 'elasticsearch',
+          mode: '0755'
+        )
+      end
+
+      it 'create directory elasticsearch plugins_dir' do
+        expect(chef_run).to create_directory('/usr/share/elasticsearch/plugins').with(
+          owner: 'elasticsearch',
+          group: 'elasticsearch',
+          mode: '0755'
+        )
+      end
 
       it 'create template elasticsearch jvm configuration file /etc/elasticsearch/jvm.options' do
         expect(chef_run).to create_template('/etc/elasticsearch/jvm.options').with(
@@ -12,8 +33,81 @@ describe 'elasticsearch-cluster::config' do
           group: 'elasticsearch',
           mode: 0600
         )
-        expect(chef_run.template('/etc/elasticsearch/jvm.options')).to notify('service[elasticsearch]').to(:restart).immediately
+        expect(chef_run.template('/etc/elasticsearch/jvm.options')).to notify('service[elasticsearch]').to(:restart).delayed
       end
+
+      it 'create template elasticsearch log configuration file /etc/elasticsearch/jvm.options' do
+        expect(chef_run).to create_template('/etc/elasticsearch/logging.yml').with(
+          cookbook: 'elasticsearch-cluster',
+          source: 'logging.yml.erb',
+          owner: 'elasticsearch',
+          group: 'elasticsearch',
+          mode: 0600
+        )
+        expect(chef_run.template('/etc/elasticsearch/logging.yml')).to notify('service[elasticsearch]').to(:restart).delayed
+      end
+
+      it 'start elasticsearch service' do
+        expect(chef_run).to enable_service('elasticsearch')
+      end
+    end
+  end
+
+  context 'rhel' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4') do |node|
+        node.automatic['platform_family'] = 'rhel'
+        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.normal['elasticsearch']['dir_mode'] = '0755'
+        node.normal['elasticsearch']['install_method'] = 'package'
+        node.normal['elasticsearch']['conf_file'] = '/etc/elasticsearch/elasticsearch.yml'
+        node.normal['elasticsearch']['logging_conf_file'] = '/etc/elasticsearch/logging.yml'
+        node.normal['elasticsearch']['plugins_dir'] = '/usr/share/elasticsearch/plugins'
+        node.normal['elasticsearch']['notify_restart'] = true
+      end.converge(described_recipe)
+    end
+
+    include_examples 'elasticsearch'
+
+    it 'create template elasticsearch env configuration file' do
+      expect(chef_run).to create_template('elasticsearch_env_file').with(
+        path: '/etc/sysconfig/elasticsearch',
+        cookbook: 'elasticsearch-cluster',
+        source: 'sysconfig.erb',
+        owner: 'root',
+        group: 'root',
+        mode: 0644
+      )
+      expect(chef_run.template('/etc/sysconfig/elasticsearch')).to notify('service[elasticsearch]').to(:restart).delayed
+    end
+  end
+
+  context 'ubuntu' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04') do |node|
+        node.automatic['platform_family'] = 'debian'
+        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.normal['elasticsearch']['dir_mode'] = '0755'
+        node.normal['elasticsearch']['install_method'] = 'package'
+        node.normal['elasticsearch']['conf_file'] = '/etc/elasticsearch/elasticsearch.yml'
+        node.normal['elasticsearch']['logging_conf_file'] = '/etc/elasticsearch/logging.yml'
+        node.normal['elasticsearch']['plugins_dir'] = '/usr/share/elasticsearch/plugins'
+        node.normal['elasticsearch']['notify_restart'] = true
+      end.converge(described_recipe)
+    end
+
+    include_examples 'elasticsearch'
+
+    it 'create template elasticsearch env configuration file' do
+      expect(chef_run).to create_template('elasticsearch_env_file').with(
+        path: '/etc/default/elasticsearch',
+        cookbook: 'elasticsearch-cluster',
+        source: 'sysconfig.erb',
+        owner: 'root',
+        group: 'root',
+        mode: 0644
+      )
+      expect(chef_run.template('/etc/default/elasticsearch')).to notify('service[elasticsearch]').to(:restart).delayed
     end
   end
 end

--- a/spec/unit/recipes/config_spec.rb
+++ b/spec/unit/recipes/config_spec.rb
@@ -57,13 +57,13 @@ describe 'elasticsearch-cluster::config' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4') do |node|
         node.automatic['platform_family'] = 'rhel'
-        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
-        node.normal['elasticsearch']['dir_mode'] = '0755'
-        node.normal['elasticsearch']['install_method'] = 'package'
-        node.normal['elasticsearch']['conf_file'] = '/etc/elasticsearch/elasticsearch.yml'
-        node.normal['elasticsearch']['logging_conf_file'] = '/etc/elasticsearch/logging.yml'
-        node.normal['elasticsearch']['plugins_dir'] = '/usr/share/elasticsearch/plugins'
-        node.normal['elasticsearch']['notify_restart'] = true
+        node.default['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.default['elasticsearch']['dir_mode'] = '0755'
+        node.default['elasticsearch']['install_method'] = 'package'
+        node.default['elasticsearch']['conf_file'] = '/etc/elasticsearch/elasticsearch.yml'
+        node.default['elasticsearch']['logging_conf_file'] = '/etc/elasticsearch/logging.yml'
+        node.default['elasticsearch']['plugins_dir'] = '/usr/share/elasticsearch/plugins'
+        node.default['elasticsearch']['notify_restart'] = true
       end.converge(described_recipe)
     end
 
@@ -86,13 +86,13 @@ describe 'elasticsearch-cluster::config' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04') do |node|
         node.automatic['platform_family'] = 'debian'
-        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
-        node.normal['elasticsearch']['dir_mode'] = '0755'
-        node.normal['elasticsearch']['install_method'] = 'package'
-        node.normal['elasticsearch']['conf_file'] = '/etc/elasticsearch/elasticsearch.yml'
-        node.normal['elasticsearch']['logging_conf_file'] = '/etc/elasticsearch/logging.yml'
-        node.normal['elasticsearch']['plugins_dir'] = '/usr/share/elasticsearch/plugins'
-        node.normal['elasticsearch']['notify_restart'] = true
+        node.default['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.default['elasticsearch']['dir_mode'] = '0755'
+        node.default['elasticsearch']['install_method'] = 'package'
+        node.default['elasticsearch']['conf_file'] = '/etc/elasticsearch/elasticsearch.yml'
+        node.default['elasticsearch']['logging_conf_file'] = '/etc/elasticsearch/logging.yml'
+        node.default['elasticsearch']['plugins_dir'] = '/usr/share/elasticsearch/plugins'
+        node.default['elasticsearch']['notify_restart'] = true
       end.converge(described_recipe)
     end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -42,7 +42,7 @@ describe 'elasticsearch-cluster::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4') do |node|
         node.automatic['platform_family'] = 'rhel'
-        node.set['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
       end.converge(described_recipe)
     end
 
@@ -53,7 +53,7 @@ describe 'elasticsearch-cluster::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04') do |node|
         node.automatic['platform_family'] = 'debian'
-        node.set['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
       end.converge(described_recipe)
     end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -42,7 +42,7 @@ describe 'elasticsearch-cluster::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4') do |node|
         node.automatic['platform_family'] = 'rhel'
-        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.default['elasticsearch']['config']['cluster.name'] = 'spec'
       end.converge(described_recipe)
     end
 
@@ -53,7 +53,7 @@ describe 'elasticsearch-cluster::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04') do |node|
         node.automatic['platform_family'] = 'debian'
-        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.default['elasticsearch']['config']['cluster.name'] = 'spec'
       end.converge(described_recipe)
     end
 

--- a/spec/unit/recipes/package_spec.rb
+++ b/spec/unit/recipes/package_spec.rb
@@ -5,8 +5,8 @@ describe 'elasticsearch-cluster::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4') do |node|
         node.automatic['platform_family'] = 'rhel'
-        node.set['elasticsearch']['install_method'] = 'package'
-        node.set['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.normal['elasticsearch']['install_method'] = 'package'
+        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
       end.converge(described_recipe)
     end
 
@@ -23,8 +23,8 @@ describe 'elasticsearch-cluster::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04') do |node|
         node.automatic['platform_family'] = 'debian'
-        node.set['elasticsearch']['install_method'] = 'package'
-        node.set['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.normal['elasticsearch']['install_method'] = 'package'
+        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
       end.converge(described_recipe)
     end
 

--- a/spec/unit/recipes/package_spec.rb
+++ b/spec/unit/recipes/package_spec.rb
@@ -5,8 +5,8 @@ describe 'elasticsearch-cluster::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4') do |node|
         node.automatic['platform_family'] = 'rhel'
-        node.normal['elasticsearch']['install_method'] = 'package'
-        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.default['elasticsearch']['install_method'] = 'package'
+        node.default['elasticsearch']['config']['cluster.name'] = 'spec'
       end.converge(described_recipe)
     end
 
@@ -23,8 +23,8 @@ describe 'elasticsearch-cluster::default' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04') do |node|
         node.automatic['platform_family'] = 'debian'
-        node.normal['elasticsearch']['install_method'] = 'package'
-        node.normal['elasticsearch']['config']['cluster.name'] = 'spec'
+        node.default['elasticsearch']['install_method'] = 'package'
+        node.default['elasticsearch']['config']['cluster.name'] = 'spec'
       end.converge(described_recipe)
     end
 

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -76,13 +76,8 @@
 #
 # For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
 
-# For ES 5.0, node settings must not contain any index level settings
-# https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_settings_changes.html#_index_level_settings
 <% @config.sort.map do |key, value| -%>
 <% if key.to_s.length != 0 && value.to_s.length != 0 -%>
-<% if Gem::Version.new(node['elasticsearch']['version']) >= Gem::Version.new('5.0.0') %>
-<% next if key.start_with?('index.', 'script.indexed', 'path.work')%>
-<% end -%>
 <%= key %>: <%= evaluate_config(value) %>
 <% end -%>
 <% end -%>

--- a/templates/default/elasticsearch.yml.erb
+++ b/templates/default/elasticsearch.yml.erb
@@ -76,8 +76,13 @@
 #
 # For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
 
+# For ES 5.0, node settings must not contain any index level settings
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_settings_changes.html#_index_level_settings
 <% @config.sort.map do |key, value| -%>
 <% if key.to_s.length != 0 && value.to_s.length != 0 -%>
+<% if Gem::Version.new(node['elasticsearch']['version']) >= Gem::Version.new('5.0.0') %>
+<% next if key.start_with?('index.', 'script.indexed', 'path.work')%>
+<% end -%>
 <%= key %>: <%= evaluate_config(value) %>
 <% end -%>
 <% end -%>

--- a/templates/default/jvm.options.erb
+++ b/templates/default/jvm.options.erb
@@ -1,0 +1,102 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xmx<%= node['elasticsearch']['sysconfig']['ES_HEAP_SIZE'] %>
+
+<% if node['elasticsearch']['sysconfig']['ES_JAVA_OPTS'] %>
+<%= node['elasticsearch']['sysconfig']['ES_JAVA_OPTS'] %>
+<% end %>
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# disable calls to System#gc
+-XX:+DisableExplicitGC
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM
+-server
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# flags to keep Netty from being unsafe
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true

--- a/templates/default/jvm.options.erb
+++ b/templates/default/jvm.options.erb
@@ -18,7 +18,10 @@
 
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
+# Setting Xms and Xmx to same value.
+# https://www.elastic.co/guide/en/elasticsearch/reference/5.0/_heap_size_check.html#_heap_size_check
 
+-Xms<%= node['elasticsearch']['sysconfig']['ES_HEAP_SIZE'] %>
 -Xmx<%= node['elasticsearch']['sysconfig']['ES_HEAP_SIZE'] %>
 
 <% if node['elasticsearch']['sysconfig']['ES_JAVA_OPTS'] %>

--- a/templates/default/sysconfig.erb
+++ b/templates/default/sysconfig.erb
@@ -29,6 +29,14 @@ WORK_DIR=<%= node['elasticsearch']['work_dir'] %>
 # Elasticsearch PID directory
 #PID_DIR=/var/run/elasticsearch
 
+# Configure restart on package upgrade (true, every other setting will lead to not restarting)
+ES_RESTART_ON_UPGRADE=<%= node['elasticsearch']['sysconfig']['ES_RESTART_ON_UPGRADE'] %>
+
+# https://www.elastic.co/guide/en/elasticsearch/reference/5.x/breaking_50_packaging.html
+# Due to ES 5.0 removed environment variables:
+# ES_MIN_MEM, ES_MAX_MEM, ES_HEAP_SIZE, ES_HEAP_NEWSIZE, ES_DIRECT_SIZE,
+# ES_USE_IPV4, ES_GC_OPTS, ES_GC_LOG_FILE, and JAVA_OPTS
+<% if Gem::Version.new(node['elasticsearch']['version']) < Gem::Version.new('5.0.0') %>
 # Heap size defaults to 256m min, 1g max
 # Set ES_HEAP_SIZE to 50% of available RAM, but no more than 31g
 ES_HEAP_SIZE=<%= node['elasticsearch']['sysconfig']['ES_HEAP_SIZE'] %>
@@ -42,11 +50,9 @@ ES_DIRECT_SIZE=<%= node['elasticsearch']['sysconfig']['ES_DIRECT_SIZE'] %>
 # Additional Java OPTS
 ES_JAVA_OPTS="<%= node['elasticsearch']['sysconfig']['ES_JAVA_OPTS'] %>"
 
-# Configure restart on package upgrade (true, every other setting will lead to not restarting)
-ES_RESTART_ON_UPGRADE=<%= node['elasticsearch']['sysconfig']['ES_RESTART_ON_UPGRADE'] %>
-
 # Path to the GC log file
 ES_GC_LOG_FILE=${LOG_DIR}/gc.log
+<% end %>
 
 ################################
 # Elasticsearch service


### PR DESCRIPTION
- Added config_v5 attributes for v5 configuration
- Added `jvm_options_file` config file for JVM configuration
- Removed JVM environment sysconfig for v5 due to [breaking changes](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/breaking_50_packaging.html)
- Spec tests
